### PR TITLE
Altered registration template to have year 'drop down' option

### DIFF
--- a/flask_app/templates/login.html
+++ b/flask_app/templates/login.html
@@ -12,7 +12,7 @@
 <body>
     <main class=" mx-auto mt-5 col-8">
             <!-- from learn platform -->
-    <!-- {% with messages = get_flashed_messages() %}
+    {% with messages = get_flashed_messages() %}
     {% if messages %}
         <div id="popup">
             {% for message in messages %}
@@ -21,7 +21,7 @@
             {% endfor%}
         </div>
     {% endif %}
-{% endwith %} -->
+    {% endwith %}
         <div class="d-grid gap-3">
             <h1 class="text-center">Researcher Village</h1>
             <h2 class="text-center">Login</h2>

--- a/flask_app/templates/register.html
+++ b/flask_app/templates/register.html
@@ -22,10 +22,10 @@
         </div>
     {% endif %}
 {% endwith %}
+
     <div class="d-grid gap-3">
         <h1 class="text-center">Student Registration</h1>
         <form class=" border mx-auto my-3 p-2 d-flex flex-column align-items-center" action ="/register" method = "post">
-            <!-- make sure names in the inputs match the column names and method names perfectly -->
             <div class="mb-4">
                 <label class="fw-bold">First Name:</label>
                 <input type="text" name="first_name">
@@ -34,10 +34,14 @@
                 <label class="fw-bold">Last Name:</label>
                 <input type="text" name="last_name">
             </div>
-            <div class="mb-4">
-                <!-- Should we make this a select element so we can control their options? Since data type is SET, it won't accept any mispellings -->
+            <div class="mb-4 d-flex justify-content-between align-items-center">
                 <label class="fw-bold">Class:</label>
-                <input type="text" name="year">
+                <select class="form-select post-input" type="select" name="year">
+                    <option value="">Freshman</option>
+                    <option value="">Sophomore</option>
+                    <option value="">Junior</option>
+                    <option value="">Senior</option>
+                </select>
             </div>
             <div class="mb-4">
                 <label class="fw-bold">Email:</label>


### PR DESCRIPTION
So I was testing everything out and came up with the below.... 
1) Register.html-Only flashed messages for first and last name populate at top of the page . For some reason the other messages  from the user.py file under Models don't populate on the screen. I am going to look more into this tomorrow. 
2) With this, I am curious to know if lines 92-94 in (Models - user.py) will have to be adjusted since the input for 'year' is now a drop down menu instead of a text input.
3) Also I tried to register a user with a password that didn't match and it still registered them.... so again, there is something my Jinja is not grabbing on the register page.
4) Once I am able to see all the validations I was going to add a red color to the validations and try to place them underneath each input. (Not sure how to do tis just yet but going to try)
5) I  got an error page when trying to crate a new project.. so with this, I am not sure what the dashboard looks like when projects start getting added.

If anyone knows an easy fix to any of these, by all means have at it! I will be back around 8:00pm tomorrow to tackle them.